### PR TITLE
Increased VStack Spacing in ContentView SwiftUI File

### DIFF
--- a/Expressions/Views/ContentView.swift
+++ b/Expressions/Views/ContentView.swift
@@ -9,11 +9,13 @@
 import SwiftUI
 
 struct ContentView: View {
+
+
     @EnvironmentObject var appStyle: AppStyle
     @ObservedObject var viewModel: ExpressionsViewModel
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 123) {
             ExpressionsView(viewModel: viewModel)
                 .font(Font.largeTitle.weight(.thin))
                 .padding([.top])

--- a/Expressions/Views/ContentView.swift
+++ b/Expressions/Views/ContentView.swift
@@ -15,7 +15,6 @@ struct ContentView: View {
     @ObservedObject var viewModel: ExpressionsViewModel
 
     var body: some View {
-        VStack(spacing: 123) {
             ExpressionsView(viewModel: viewModel)
                 .font(Font.largeTitle.weight(.thin))
                 .padding([.top])


### PR DESCRIPTION
### TL;DR

This PR introduces changes to the ContentView in the Expressions app, namely adjusting the vertical spacing within the VStack.

### What changed?

The vertical spacing within the VStack in ContentView.swift has been changed from 0 to 123, resulting in increased spacing between elements within the stack.

### How to test?

This change can be tested by running the app and observing the new layout spacing in the ContentView.

### Why make this change?

The motivation behind this PR was to enhance the visual appeal and readability of the ContentView by implementing more space between the elements.

---

